### PR TITLE
Fix error when not copying an Object even if the Object has a PhysBone attached to it

### DIFF
--- a/Editor/VRoidAvatar.cs
+++ b/Editor/VRoidAvatar.cs
@@ -63,7 +63,7 @@ namespace Jirko.Unity.VRoidAvatarUtils
         //// Expressions
         public bool expressionsMenu = true;
         public bool expressionParameters = true;
-        
+
         // Pipeline Manager
         public bool blueprintId = true;
 
@@ -372,6 +372,11 @@ namespace Jirko.Unity.VRoidAvatarUtils
                 physBones = cloneGameObject.GetComponentsInChildren<VRCPhysBone>();
                 foreach (var phy in physBones)
                 {
+                    if (targetObject.transform.Find(phy.gameObject.GetFullPath()) == null)
+                    {
+                        continue;
+                    }
+
                     if (avatarMode == 0)
                     {
                         if (checkExclutionPhysBoneContain(phy.rootTransform.name))
@@ -497,6 +502,11 @@ namespace Jirko.Unity.VRoidAvatarUtils
                 {
                     foreach (T constraint in constraints)
                     {
+                        if (targetObject.transform.Find(constraint.gameObject.GetFullPath()) == null)
+                        {
+                            continue;
+                        }
+
                         List<ConstraintSource> dest = new List<ConstraintSource>();
                         List<ConstraintSource> from = new List<ConstraintSource>();
                         constraint.GetSources(from);


### PR DESCRIPTION
Objectをコピーしない場合でもObjectについているPhysBoneをコピーしようとしてエラーとなっていました。
そのため、対象Objectが見つからない場合は処理をスキップするようにしました。

また、constraintでも同様の事象が発生していたため水平展開しました。

ref: #17 